### PR TITLE
Tallyson

### DIFF
--- a/BackEnd/.gitignore
+++ b/BackEnd/.gitignore
@@ -1,1 +1,1 @@
-banco.sql
+conserva_cidadao.sql

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/ConservaCidadaoAppApplication.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/ConservaCidadaoAppApplication.java
@@ -3,7 +3,6 @@ package com.POA.conserva_cidadao_app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-// REMOVA estas anotações, não são mais necessárias
 @SpringBootApplication
 public class ConservaCidadaoAppApplication {
 	public static void main(String[] args) {

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/controller/DenunciaController.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/controller/DenunciaController.java
@@ -1,0 +1,95 @@
+package com.POA.conserva_cidadao_app.controller;
+
+import com.POA.conserva_cidadao_app.model.Denuncia;
+import com.POA.conserva_cidadao_app.model.StatusDenuncia;
+import com.POA.conserva_cidadao_app.service.DenunciaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/denuncias")
+public class DenunciaController {
+
+    @Autowired
+    private DenunciaService denunciaService;
+
+    @GetMapping
+    public List<Denuncia> listarTodasDenuncias() {
+        return denunciaService.listarTodasDenuncias();
+    }
+
+    @PostMapping
+    public ResponseEntity<?> criarDenuncia(@RequestBody Denuncia denuncia) {
+        try {
+            Denuncia novaDenuncia = denunciaService.criarDenuncia(denuncia);
+            return ResponseEntity.ok(Map.of(
+                    "mensagem", "Denúncia registrada com sucesso.",
+                    "denuncia", Map.of(
+                            "id", novaDenuncia.getId(),
+                            "status", novaDenuncia.getStatus().toString()
+                    )
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "status_code", 400,
+                    "erro", e.getMessage()
+            ));
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> buscarDenunciaPorId(@PathVariable Long id) {
+        Optional<Denuncia> denuncia = denunciaService.buscarDenunciaPorId(id);
+        if (denuncia.isPresent()) {
+            return ResponseEntity.ok(denuncia.get());
+        } else {
+            return ResponseEntity.status(404).body(Map.of(
+                    "status_code", 404,
+                    "erro", "Denúncia não encontrada."
+            ));
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> atualizarStatusDenuncia(@PathVariable Long id, @RequestBody Map<String, String> body) {
+        try {
+            StatusDenuncia novoStatus = StatusDenuncia.valueOf(body.get("status").toUpperCase());
+            Denuncia denunciaAtualizada = denunciaService.atualizarStatusDenuncia(id, novoStatus);
+            return ResponseEntity.ok(Map.of(
+                    "mensagem", "Denúncia atualizada com sucesso.",
+                    "denuncia", Map.of(
+                            "id", denunciaAtualizada.getId(),
+                            "status", denunciaAtualizada.getStatus().toString()
+                    )
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "status_code", 404,
+                    "erro", "Denúncia não encontrada."
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body(Map.of(
+                    "status_code", 400,
+                    "erro", "Status inválido"
+            ));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deletarDenuncia(@PathVariable Long id) {
+        try {
+            denunciaService.deletarDenuncia(id);
+            return ResponseEntity.ok(Map.of("mensagem", "Denúncia excluída com sucesso."));
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "status_code", 404,
+                    "erro", "Denúncia não encontrada ou você não tem permissão."
+            ));
+        }
+    }
+}

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/Denuncia.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/Denuncia.java
@@ -1,0 +1,50 @@
+package com.POA.conserva_cidadao_app.model;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "denuncias")
+public class Denuncia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private String titulo;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String descricao;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusDenuncia status = StatusDenuncia.DENUNCIADO;
+
+    @Column(nullable = false)
+    private int likes = 0;
+
+    @ElementCollection
+    @CollectionTable(name = "denuncia_imagens", joinColumns = @JoinColumn(name = "denuncia_id"))
+    @Column(name = "imagem")
+    private List<String> imagens;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Usuario getUsuario() { return usuario; }
+    public void setUsuario(Usuario usuario) { this.usuario = usuario; }
+    public String getTitulo() { return titulo; }
+    public void setTitulo(String titulo) { this.titulo = titulo; }
+    public String getDescricao() { return descricao; }
+    public void setDescricao(String descricao) { this.descricao = descricao; }
+    public StatusDenuncia getStatus() { return status; }
+    public void setStatus(StatusDenuncia status) { this.status = status; }
+    public int getLikes() { return likes; }
+    public void setLikes(int likes) { this.likes = likes; }
+    public List<String> getImagens() { return imagens; }
+    public void setImagens(List<String> imagens) { this.imagens = imagens; }
+}

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/StatusDenuncia.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/StatusDenuncia.java
@@ -1,0 +1,8 @@
+package com.POA.conserva_cidadao_app.model;
+
+public enum StatusDenuncia {
+    DENUNCIADO,
+    EM_ANDAMENTO,
+    RESOLVIDO,
+    INVALIDO
+}

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/Usuario.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/model/Usuario.java
@@ -23,7 +23,6 @@ public class Usuario {
     public Usuario() {
     }
 
-    // Getters e Setters (MANTIDOS)
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public String getNome() { return nome; }

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/repository/DenunciaRepository.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/repository/DenunciaRepository.java
@@ -1,0 +1,9 @@
+package com.POA.conserva_cidadao_app.repository;
+
+import com.POA.conserva_cidadao_app.model.Denuncia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface DenunciaRepository extends JpaRepository<Denuncia, Long> {
+    List<Denuncia> findAll();
+}

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/service/AuthService.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/service/AuthService.java
@@ -1,7 +1,4 @@
 package com.POA.conserva_cidadao_app.service;
-
-// Atualize os imports
-
 import com.POA.conserva_cidadao_app.model.Usuario;
 import com.POA.conserva_cidadao_app.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +39,6 @@ public class AuthService {
             return response;
         }
 
-        // Garante o role padrão
         if (novoUsuario.getRole() == null) {
             novoUsuario.setRole("usuario");
         }

--- a/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/service/DenunciaService.java
+++ b/BackEnd/conserva-cidadao-app/src/main/java/com/POA/conserva_cidadao_app/service/DenunciaService.java
@@ -1,0 +1,42 @@
+package com.POA.conserva_cidadao_app.service;
+
+import com.POA.conserva_cidadao_app.model.Denuncia;
+import com.POA.conserva_cidadao_app.model.StatusDenuncia;
+import com.POA.conserva_cidadao_app.repository.DenunciaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DenunciaService {
+
+    @Autowired
+    private DenunciaRepository denunciaRepository;
+
+    public List<Denuncia> listarTodasDenuncias() {
+        return denunciaRepository.findAll();
+    }
+
+    public Denuncia criarDenuncia(Denuncia denuncia) {
+        if (denuncia.getImagens() != null && denuncia.getImagens().size() > 4) {
+            throw new IllegalArgumentException("Número de imagens excede o limite permitido (4).");
+        }
+        return denunciaRepository.save(denuncia);
+    }
+
+    public Optional<Denuncia> buscarDenunciaPorId(Long id) {
+        return denunciaRepository.findById(id);
+    }
+
+    public Denuncia atualizarStatusDenuncia(Long id, StatusDenuncia novoStatus) {
+        Denuncia denuncia = denunciaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Denúncia não encontrada."));
+        denuncia.setStatus(novoStatus);
+        return denunciaRepository.save(denuncia);
+    }
+
+    public void deletarDenuncia(Long id) {
+        denunciaRepository.deleteById(id);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ POST http://localhost:3001/denuncias:
     "titulo": "Balanço quebrado",
     "descricao": "balanços e brinquedos quebrados na praça",
     "imagens": ["img1.jpg", "img2.jpg"] OBS: ainda não está preparado pra receber imagens em si
-  }
+    }
 
 
 PUT http://localhost:3001/denuncias/id_da_denuncia
@@ -72,10 +72,10 @@ ENUMS de status:
     RESOLVIDO,
     INVALIDO
 
-    JSON do put OBS: somente usuario com role admin faz a atualização de status de denuncias
-{
-  "status": "EM_ANDAMENTO"
-}
+    JSON do put OBS: somente usuario com role admin faz a atualização de status de denuncias:
+    {
+      "status": "EM_ANDAMENTO"
+    }
 
 DELETE http://localhost:3001/denuncias/id_da_denuncia
 OBS: por enquanto ainda não está setado para somente o admin e o criador da denuncia excluir a denuncia X

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-onserva Cidadão - Backend
+Conserva Cidadão - Backend
 Este é o backend do projeto Conserva Cidadão, desenvolvido com Spring Boot e PostgreSQL. O sistema fornece endpoints para autenticação e gerenciamento de usuários.
 
 PASSO 01:

--- a/README.md
+++ b/README.md
@@ -47,3 +47,37 @@ Content-Type: application/json
 }
 
 GET http://localhost:3001/status OBS: Endpoint para testar se o projeto foi compilado corretamente e a API está rodando na porta 3001.
+
+
+DENUNCIAS
+
+GET http://localhost:3001/denuncias - para receber todas as denuncias registradas
+
+POST http://localhost:3001/denuncias:
+    
+    JSON do post
+{
+  "usuario": {"id": 1},
+  "titulo": "Balanço quebrado",
+  "descricao": "balanços e brinquedos quebrados na praça",
+  "imagens": ["img1.jpg", "img2.jpg"] OBS: ainda não está preparado pra receber imagens em si
+}
+
+
+PUT http://localhost:3001/denuncias/id_da_denuncia
+
+ENUMS de status:
+    DENUNCIADO, OBS: Denunciado é o status inicial, ovbviamente não há necessidade de um put voltar para DENUNCIADO
+    EM_ANDAMENTO,
+    RESOLVIDO,
+    INVALIDO
+
+    JSON do put OBS: somente usuario com role admin faz a atualização de status de denuncias
+{
+  "status": "EM_ANDAMENTO"
+}
+
+DELETE http://localhost:3001/denuncias/id_da_denuncia
+OBS: por enquanto ainda não está setado para somente o admin e o criador da denuncia excluir a denuncia X
+
+    JSON do delete não existe, só mandar a requisição do tipo delete com o id da denuncia

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ GET http://localhost:3001/denuncias - para receber todas as denuncias registrada
 
 POST http://localhost:3001/denuncias:
     
-    JSON do post
-{
-  "usuario": {"id": 1},
-  "titulo": "Balanço quebrado",
-  "descricao": "balanços e brinquedos quebrados na praça",
-  "imagens": ["img1.jpg", "img2.jpg"] OBS: ainda não está preparado pra receber imagens em si
-}
+    JSON do post: 
+    {
+    "usuario": {"id": 1},
+    "titulo": "Balanço quebrado",
+    "descricao": "balanços e brinquedos quebrados na praça",
+    "imagens": ["img1.jpg", "img2.jpg"] OBS: ainda não está preparado pra receber imagens em si
+  }
 
 
 PUT http://localhost:3001/denuncias/id_da_denuncia


### PR DESCRIPTION
crud de denuncias iniciado.

ENTROU: get de todas as denuncias, get de denuncia por id (DISCUTÍVEL), PUT de status da denuncia, delete da denuncia por id.

FALTA: lidar com inputs de imagem, separar responsabilidades do put e delete de denuncias, em que no PUT somente o admin poderá atualizar o status da denuncia e o delete o admin e o usuario criador da denuncia deverão poder deletar.